### PR TITLE
fix: ItemInstance and Inventory not genericized

### DIFF
--- a/Runtime/Inventory/InventorySystem/IInventory.cs
+++ b/Runtime/Inventory/InventorySystem/IInventory.cs
@@ -1,9 +1,11 @@
 namespace SoulShard.InventorySystem
 {
-    public interface IInventory<_BaseItem, _Slot>
+    public interface IInventory<_BaseItem, _Slot, _ItemInstance>
         where _BaseItem : class, IBaseItem
-        where _Slot : class, ISlot<_BaseItem>, new()
+        where _ItemInstance : struct, IItemInstance<_BaseItem>
+        where _Slot : class, ISlot<_BaseItem, _ItemInstance>, new()
     {
         public _Slot[] slots { get; set; }
+        public uint capacity { get; }
     }
 }

--- a/Runtime/Inventory/InventorySystem/Inventory.cs
+++ b/Runtime/Inventory/InventorySystem/Inventory.cs
@@ -5,15 +5,16 @@ namespace SoulShard.InventorySystem
     /// </summary>
     /// <typeparam name="_BaseItem">The base item.</typeparam>
     /// <typeparam name="_Slot">The slot type.</typeparam>
-    public class Inventory<_BaseItem, _Slot> : IInventory<_BaseItem, _Slot>
+    public class Inventory<_BaseItem, _Slot, _ItemInstance> : IInventory<_BaseItem, _Slot, _ItemInstance>
         where _BaseItem : class, IBaseItem
-        where _Slot : class, ISlot<_BaseItem>, new()
+        where _ItemInstance : struct, IItemInstance<_BaseItem>
+        where _Slot : class, ISlot<_BaseItem, _ItemInstance>, new()
     {
         /// <summary>
         /// The slots within this inventory.
         /// </summary>
         public _Slot[] slots { get; set; }
-
+        
         /// <summary>
         /// The remaining capacity of this inventory.
         /// </summary>
@@ -29,7 +30,7 @@ namespace SoulShard.InventorySystem
             }
         }
 
-        public Inventory(ItemInstance<_BaseItem>[] PointerItems)
+        public Inventory(_ItemInstance[] PointerItems)
         {
             slots = new _Slot[PointerItems.Length];
             for (int i = 0; i < PointerItems.Length; i++)
@@ -38,5 +39,10 @@ namespace SoulShard.InventorySystem
                 slots[i].itemInstance = PointerItems[i];
             }
         }
+
+        public virtual void AddItem(_ItemInstance other) => 
+            InventoryManagementUtilities.AddItemToInventory<_BaseItem,_Slot,_ItemInstance,IInventory<_BaseItem,_Slot,_ItemInstance>>(this, other);
+        public virtual void ContainsItem(_ItemInstance other) => 
+            InventoryManagementUtilities.ContainsItem<_BaseItem, _Slot, _ItemInstance, IInventory<_BaseItem, _Slot, _ItemInstance>>(this, other);
     }
 }

--- a/Runtime/Inventory/InventorySystem/InventoryManagementFuncs.cs
+++ b/Runtime/Inventory/InventorySystem/InventoryManagementFuncs.cs
@@ -1,13 +1,15 @@
 namespace SoulShard.InventorySystem
 {
-    public static class InventoryManagementUtilities
+    public struct InventoryManagementUtilities
     {
-        public static ItemInstance<_BaseItem> AddUnstackableItemToInventory<_BaseItem, _Slot>(
-            Inventory<_BaseItem, _Slot> inventory,
-            ItemInstance<_BaseItem> other
+        public static _ItemInstance AddUnstackableItemToInventory<_BaseItem, _Slot, _ItemInstance, _Inventory>(
+            _Inventory inventory,
+            _ItemInstance other
         )
             where _BaseItem : class, IBaseItem
-            where _Slot : class, ISlot<_BaseItem>, new()
+            where _ItemInstance : struct, IItemInstance<_BaseItem>
+            where _Slot : class, ISlot<_BaseItem, _ItemInstance>, new()
+            where _Inventory: class, IInventory<_BaseItem,_Slot,_ItemInstance>
         {
             if (other.isEmpty)
                 return other;
@@ -19,18 +21,20 @@ namespace SoulShard.InventorySystem
                 if (inventory.slots[i].isEmpty)
                 {
                     inventory.slots[i].itemInstance = other;
-                    return new ItemInstance<_BaseItem>();
+                    return new _ItemInstance();
                 }
             }
             return other;
         }
 
-        public static ItemInstance<_BaseItem> AddStackableItemToInventory<_BaseItem, _Slot>(
-            Inventory<_BaseItem, _Slot> inventory,
-            ItemInstance<_BaseItem> other
+        public static _ItemInstance AddStackableItemToInventory<_BaseItem, _Slot, _ItemInstance, _Inventory>(
+            _Inventory inventory,
+            _ItemInstance other
         )
             where _BaseItem : class, IBaseItem
-            where _Slot : class, ISlot<_BaseItem>, new()
+            where _ItemInstance : struct, IItemInstance<_BaseItem>
+            where _Slot : class, ISlot<_BaseItem, _ItemInstance>, new()
+            where _Inventory : class, IInventory<_BaseItem, _Slot, _ItemInstance>
         {
             if (other.isEmpty)
                 return other;
@@ -40,7 +44,7 @@ namespace SoulShard.InventorySystem
             uint maxStack = other.item.maxStackAmount;
 
             if (other.amount == maxStack)
-                return AddUnstackableItemToInventory(inventory, other);
+                return AddUnstackableItemToInventory<_BaseItem,_Slot,_ItemInstance,_Inventory>(inventory, other);
 
             for (int i = 0; i < inventory.slots.Length; i++)
             {
@@ -52,31 +56,33 @@ namespace SoulShard.InventorySystem
                         continue;
                     if (inventory.slots[i].itemInstance.amount + other.amount < maxStack)
                     {
-                        ItemInstance<_BaseItem> newItem = inventory.slots[i].itemInstance;
+                        _ItemInstance newItem = inventory.slots[i].itemInstance;
                         newItem.amount += other.amount;
                         inventory.slots[i].itemInstance = newItem;
-                        return new ItemInstance<_BaseItem>();
+                        return new _ItemInstance();
                     }
 
                     other.amount -= maxStack - inventory.slots[i].itemInstance.amount;
-                    ItemInstance<_BaseItem> newItem2 = inventory.slots[i].itemInstance;
+                    _ItemInstance newItem2 = inventory.slots[i].itemInstance;
                     newItem2.amount = maxStack;
                     inventory.slots[i].itemInstance = newItem2;
                 }
             }
 
             if (other.amount > 0)
-                return AddUnstackableItemToInventory(inventory, other);
+                return AddUnstackableItemToInventory<_BaseItem, _Slot, _ItemInstance, _Inventory>(inventory, other);
 
             return other;
         }
 
-        public static ItemInstance<_BaseItem> AddItemToInventory<_BaseItem, _Slot>(
-            Inventory<_BaseItem, _Slot> inventory,
-            ItemInstance<_BaseItem> other
+        public static _ItemInstance AddItemToInventory<_BaseItem, _Slot, _ItemInstance, _Inventory>(
+            _Inventory inventory,
+            _ItemInstance other
         )
             where _BaseItem : class, IBaseItem
-            where _Slot : class, ISlot<_BaseItem>, new()
+            where _ItemInstance : struct, IItemInstance<_BaseItem>
+            where _Slot : class, ISlot<_BaseItem, _ItemInstance>, new()
+            where _Inventory : class, IInventory<_BaseItem, _Slot, _ItemInstance>
         {
             if (other.isEmpty)
                 return other;
@@ -84,17 +90,19 @@ namespace SoulShard.InventorySystem
                 return other;
 
             if (!other.item.isStackable)
-                return AddUnstackableItemToInventory(inventory, other);
-            return AddStackableItemToInventory(inventory, other);
+                return AddUnstackableItemToInventory<_BaseItem, _Slot, _ItemInstance, _Inventory>(inventory, other);
+            return AddStackableItemToInventory<_BaseItem, _Slot, _ItemInstance, _Inventory>(inventory, other);
         }
 
         // checks if the inventory contains a specific item
-        public static bool ContainsItem<_BaseItem, _Slot>(
-            Inventory<_BaseItem, _Slot> inventory,
-            ItemInstance<_BaseItem> other
+        public static bool ContainsItem<_BaseItem, _Slot, _ItemInstance, _Inventory>(
+            _Inventory inventory,
+            _ItemInstance other
         )
             where _BaseItem : class, IBaseItem
-            where _Slot : class, ISlot<_BaseItem>, new()
+            where _ItemInstance : struct, IItemInstance<_BaseItem>
+            where _Slot : class, ISlot<_BaseItem, _ItemInstance>, new()
+            where _Inventory : class, IInventory<_BaseItem, _Slot, _ItemInstance>
         {
             if (other.isEmpty)
                 return false;

--- a/Runtime/Inventory/Item/IItemInstance.cs
+++ b/Runtime/Inventory/Item/IItemInstance.cs
@@ -1,0 +1,25 @@
+namespace SoulShard.InventorySystem
+{
+    /// <summary>
+    /// An instance of an item.
+    /// </summary>
+    /// <typeparam name="_BaseItem">The "item prefab" to use as the base for this instance.</typeparam>
+
+    public interface IItemInstance<_BaseItem> where _BaseItem : class, IBaseItem
+    {
+        /// <summary>
+        /// The Base item this pointeritem is instanced off of.
+        /// </summary>
+        public _BaseItem item { get; set; }
+
+        /// <summary>
+        /// The quantity of this item.
+        /// </summary>
+        public uint amount { get; set; }
+
+        /// <summary>
+        /// Is this an empty item instance?
+        /// </summary>
+        public bool isEmpty { get; }
+    }
+}

--- a/Runtime/Inventory/Item/IItemInstance.cs.meta
+++ b/Runtime/Inventory/Item/IItemInstance.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: e2ce4c4b307f64c48a5ac99da2b35c45
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Inventory/Item/ItemInstance.cs
+++ b/Runtime/Inventory/Item/ItemInstance.cs
@@ -5,38 +5,31 @@ namespace SoulShard.InventorySystem
     /// </summary>
     /// <typeparam name="_BaseItem">The "item prefab" to use as the base for this instance.</typeparam>
     [System.Serializable]
-    public struct ItemInstance<_BaseItem> where _BaseItem : class, IBaseItem
+    public struct ItemInstance<_BaseItem>: IItemInstance<_BaseItem> where _BaseItem : class, IBaseItem
     {
-        /// <summary>
-        /// The Base item this pointeritem is instanced off of.
-        /// </summary>
-        public _BaseItem item;
-
-        /// <summary>
-        /// The quantity of this item.
-        /// </summary>
-        public uint amount;
-
-        /// <summary>
-        /// Is this an empty item instance?
-        /// </summary>
+        _BaseItem _item;
+        uint _amount;
         public bool isEmpty
         {
             get => item == null;
         }
+        public _BaseItem item { get => _item; set => _item = value; }
+        public uint amount { get => _amount; set => _amount = value; }
 
         #region Constructors
         public ItemInstance(_BaseItem item = null, uint amount = 0)
         {
-            this.item = item;
-            this.amount = amount;
+            _item = item;
+            _amount = amount;
         }
 
         public ItemInstance(ItemInstance<_BaseItem> I)
         {
-            item = I.item;
-            amount = I.amount;
+            _item = I.item;
+            _amount = I.amount;
         }
+        public ItemInstance<_BaseItem> Make(ItemInstance<_BaseItem> I) => new ItemInstance<_BaseItem>(I);
+        public ItemInstance<_BaseItem> Make(_BaseItem item = null, uint amount = 0) => new ItemInstance<_BaseItem>(item, amount);
         #endregion
     }
 }

--- a/Runtime/Inventory/Slot/ISlot.cs
+++ b/Runtime/Inventory/Slot/ISlot.cs
@@ -1,16 +1,16 @@
 namespace SoulShard.InventorySystem
 {
-    public interface ISlot<_BaseItem> where _BaseItem : class, IBaseItem
+    public interface ISlot<_BaseItem, _ItemInstance> where _BaseItem : class, IBaseItem where _ItemInstance : struct, IItemInstance<_BaseItem>
     {
         /// <summary>
         /// The item instance this slot stores.
         /// </summary>
-        public ItemInstance<_BaseItem> itemInstance { get; set; }
+        public _ItemInstance itemInstance { get; set; }
 
         /// <summary>
         /// The function to invoke when an item is modified
         /// </summary>
-        public System.Action<ItemInstance<_BaseItem>> onItemModified { get; set; }
+        public System.Action<_ItemInstance> onItemModified { get; set; }
 
         /// <summary>
         /// Make a transfer between this slot and the hand.
@@ -18,7 +18,7 @@ namespace SoulShard.InventorySystem
         /// <param name="button">The mouse button pressed to make the transfer with</param>
         /// <param name="other">The pointeritem in the hand</param>
         /// <returns>The new item held by the hand.</returns>
-        public ItemInstance<_BaseItem> Transfer(ItemInstance<_BaseItem> other, string button = "");
+        public _ItemInstance Transfer(_ItemInstance other, string button = "");
 
         /// <summary>
         /// Whether the slot is empty (thanks nullable types!!!!)

--- a/Runtime/Inventory/Slot/Slot.cs
+++ b/Runtime/Inventory/Slot/Slot.cs
@@ -4,11 +4,13 @@ namespace SoulShard.InventorySystem
     /// The basic item slot manager.
     /// </summary>
     /// <typeparam name="_BaseItem">The base item type this slot stores.</typeparam>
-    public class Slot<_BaseItem> : ISlot<_BaseItem> where _BaseItem : class, IBaseItem
+    public class Slot<_BaseItem, _ItemInstance> : ISlot<_BaseItem, _ItemInstance> 
+        where _BaseItem : class, IBaseItem 
+        where _ItemInstance: struct, IItemInstance<_BaseItem>
     {
-        ItemInstance<_BaseItem> item;
-
-        public ItemInstance<_BaseItem> itemInstance
+        _ItemInstance item;
+        public System.Action<_ItemInstance> onItemModified { get; set; }
+        public _ItemInstance itemInstance
         {
             get => item;
             set
@@ -18,23 +20,21 @@ namespace SoulShard.InventorySystem
             }
         }
 
-        public System.Action<ItemInstance<_BaseItem>> onItemModified { get; set; }
+        public Slot(_ItemInstance item) => itemInstance = item;
 
-        public Slot(ItemInstance<_BaseItem> item) => itemInstance = item;
-
-        public Slot() => itemInstance = new ItemInstance<_BaseItem>();
+        public Slot() => itemInstance = new _ItemInstance();
 
         public bool isEmpty
         {
             get => item.item == null;
         }
 
-        public virtual ItemInstance<_BaseItem> Transfer(
-            ItemInstance<_BaseItem> other,
+        public virtual _ItemInstance Transfer(
+            _ItemInstance other,
             string button = ""
         )
         {
-            ItemInstance<_BaseItem> originalItem = itemInstance;
+            _ItemInstance originalItem = itemInstance;
             itemInstance = other;
             onItemModified?.Invoke(itemInstance);
             return originalItem;

--- a/Tests/EditMode/Inventory/Helpers.cs
+++ b/Tests/EditMode/Inventory/Helpers.cs
@@ -17,13 +17,13 @@ namespace SoulShard.Tests.InventorySystem
             isStackable: true
         );
 
-        public static Inventory<BaseItem, Slot<BaseItem>> GetFullInventory() =>
-            new Inventory<BaseItem, Slot<BaseItem>>(
+        public static Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>> GetFullInventory() =>
+            new Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>(
                 new ItemInstance<BaseItem>[1] { new ItemInstance<BaseItem>(witchesBrew) }
             );
 
-        public static Inventory<BaseItem, Slot<BaseItem>> GetHoleyInventory() =>
-            new Inventory<BaseItem, Slot<BaseItem>>(
+        public static Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>> GetHoleyInventory() =>
+            new Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>(
                 new ItemInstance<BaseItem>[10]
                 {
                     new ItemInstance<BaseItem>(salt, 69),
@@ -40,19 +40,19 @@ namespace SoulShard.Tests.InventorySystem
             );
 
         public static System.Func<
-            Inventory<BaseItem, Slot<BaseItem>>,
+            Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>,
             ItemInstance<BaseItem>,
             ItemInstance<BaseItem>
         >[] addItemFuncs() =>
             new System.Func<
-                Inventory<BaseItem, Slot<BaseItem>>,
+                Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>,
                 ItemInstance<BaseItem>,
                 ItemInstance<BaseItem>
             >[3]
             {
-                InventoryManagementUtilities.AddItemToInventory,
-                InventoryManagementUtilities.AddStackableItemToInventory,
-                InventoryManagementUtilities.AddUnstackableItemToInventory
+                InventoryManagementUtilities.AddItemToInventory<BaseItem,Slot<BaseItem, ItemInstance<BaseItem>>,ItemInstance<BaseItem>,Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>>,
+                InventoryManagementUtilities.AddStackableItemToInventory<BaseItem,Slot<BaseItem, ItemInstance<BaseItem>>,ItemInstance<BaseItem>,Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>>,
+                InventoryManagementUtilities.AddUnstackableItemToInventory<BaseItem,Slot<BaseItem, ItemInstance<BaseItem>>,ItemInstance<BaseItem>,Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>>
             };
     }
 }

--- a/Tests/EditMode/Inventory/TestInventoryManagementUtilities.cs
+++ b/Tests/EditMode/Inventory/TestInventoryManagementUtilities.cs
@@ -21,15 +21,15 @@ namespace SoulShard.Tests.InventorySystem
         public void TestAddUnstackableToInventory()
         {
             var inven = Helpers.GetHoleyInventory();
-            InventoryManagementUtilities.AddUnstackableItemToInventory(
+            InventoryManagementUtilities.AddUnstackableItemToInventory< BaseItem,Slot<BaseItem, ItemInstance<BaseItem>>,ItemInstance<BaseItem>,Inventory<BaseItem,Slot<BaseItem,ItemInstance<BaseItem>>,ItemInstance<BaseItem>>> (
                 inven,
                 new ItemInstance<BaseItem>(Helpers.witchesBrew)
             );
-            InventoryManagementUtilities.AddUnstackableItemToInventory(
+            InventoryManagementUtilities.AddUnstackableItemToInventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>, Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>>(
                 inven,
                 new ItemInstance<BaseItem>(Helpers.AXE)
             );
-            InventoryManagementUtilities.AddUnstackableItemToInventory(
+            InventoryManagementUtilities.AddUnstackableItemToInventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>, Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>>(
                 inven,
                 new ItemInstance<BaseItem>(Helpers.AXE)
             );
@@ -42,13 +42,13 @@ namespace SoulShard.Tests.InventorySystem
         public void TestAddStackableItemToInventory()
         {
             var inven = Helpers.GetHoleyInventory();
-            InventoryManagementUtilities.AddStackableItemToInventory(
+            InventoryManagementUtilities.AddStackableItemToInventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>, Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>>(
                 inven,
                 new ItemInstance<BaseItem>(Helpers.salt, 10)
             );
             Assert.AreEqual(inven.slots[0].itemInstance.amount, 79);
             Assert.AreEqual(inven.slots[0].itemInstance.item.name, Helpers.salt.name);
-            InventoryManagementUtilities.AddStackableItemToInventory(
+            InventoryManagementUtilities.AddStackableItemToInventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>, Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>>(
                 inven,
                 new ItemInstance<BaseItem>(Helpers.salt, 30)
             );
@@ -63,28 +63,28 @@ namespace SoulShard.Tests.InventorySystem
         {
             var inven = Helpers.GetHoleyInventory();
             Assert.AreEqual(
-                InventoryManagementUtilities.ContainsItem(
+                InventoryManagementUtilities.ContainsItem<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>, Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>>(
                     inven,
                     new ItemInstance<BaseItem>(Helpers.salt, 69)
                 ),
                 true
             );
             Assert.AreEqual(
-                InventoryManagementUtilities.ContainsItem(
+                InventoryManagementUtilities.ContainsItem<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>, Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>>(
                     inven,
                     new ItemInstance<BaseItem>(Helpers.salt, 39)
                 ),
                 false
             );
             Assert.AreEqual(
-                InventoryManagementUtilities.ContainsItem(
+                InventoryManagementUtilities.ContainsItem<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>, Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>>(
                     inven,
                     new ItemInstance<BaseItem>(Helpers.AXE, 0)
                 ),
                 false
             );
             Assert.AreEqual(
-                InventoryManagementUtilities.ContainsItem(
+                InventoryManagementUtilities.ContainsItem<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>, Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>>(
                     inven,
                     new ItemInstance<BaseItem>(Helpers.witchesBrew, 0)
                 ),

--- a/Tests/EditMode/Inventory/TestSlot.cs
+++ b/Tests/EditMode/Inventory/TestSlot.cs
@@ -8,7 +8,7 @@ namespace SoulShard.Tests.InventorySystem
         [Test]
         public void TestSlotTransfer()
         {
-            Slot<BaseItem> slot = new Slot<BaseItem>(new ItemInstance<BaseItem>(Helpers.salt, 12));
+            Slot<BaseItem, ItemInstance<BaseItem>> slot = new Slot<BaseItem, ItemInstance<BaseItem>>(new ItemInstance<BaseItem>(Helpers.salt, 12));
             var res = slot.Transfer(new ItemInstance<BaseItem>(Helpers.AXE));
             Assert.AreEqual(res.amount, 12);
             Assert.AreEqual(res.item.name, Helpers.salt.name);
@@ -20,7 +20,7 @@ namespace SoulShard.Tests.InventorySystem
         public void TestOnItemModifed()
         {
             ItemInstance<BaseItem> res = new ItemInstance<BaseItem>();
-            Slot<BaseItem> slot = new Slot<BaseItem>(new ItemInstance<BaseItem>(Helpers.salt, 12));
+            Slot<BaseItem, ItemInstance<BaseItem>> slot = new Slot<BaseItem, ItemInstance<BaseItem>>(new ItemInstance<BaseItem>(Helpers.salt, 12));
             slot.onItemModified = (ItemInstance<BaseItem> item) => res = item;
             var testTransfer = new ItemInstance<BaseItem>(Helpers.AXE);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.soulshardstudios.soulshardutilities",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "displayName": "SoulShardUtilities",
   "description": "A collection of usefull project independant functions, constants, and utilities.",
   "unity": "2019.1",


### PR DESCRIPTION
I tried to use this in ThrowEverything and immediately came upon the wall of not being able to use the default Item Instance because it has no durability, and structs cant use inheritance (not to mention not genericizing it can just lead to bad things...)