### PR TITLE
feat: Add slot management functions

### DIFF
--- a/Runtime/Inventory/Item/ItemInstance.cs
+++ b/Runtime/Inventory/Item/ItemInstance.cs
@@ -5,7 +5,8 @@ namespace SoulShard.InventorySystem
     /// </summary>
     /// <typeparam name="_BaseItem">The "item prefab" to use as the base for this instance.</typeparam>
     [System.Serializable]
-    public struct ItemInstance<_BaseItem>: IItemInstance<_BaseItem> where _BaseItem : class, IBaseItem
+    public struct ItemInstance<_BaseItem> : IItemInstance<_BaseItem>
+        where _BaseItem : class, IBaseItem
     {
         _BaseItem _item;
         uint _amount;
@@ -13,8 +14,16 @@ namespace SoulShard.InventorySystem
         {
             get => item == null;
         }
-        public _BaseItem item { get => _item; set => _item = value; }
-        public uint amount { get => _amount; set => _amount = value; }
+        public _BaseItem item
+        {
+            get => _item;
+            set => _item = value;
+        }
+        public uint amount
+        {
+            get => _amount;
+            set => _amount = value;
+        }
 
         #region Constructors
         public ItemInstance(_BaseItem item = null, uint amount = 0)
@@ -28,8 +37,6 @@ namespace SoulShard.InventorySystem
             _item = I.item;
             _amount = I.amount;
         }
-        public ItemInstance<_BaseItem> Make(ItemInstance<_BaseItem> I) => new ItemInstance<_BaseItem>(I);
-        public ItemInstance<_BaseItem> Make(_BaseItem item = null, uint amount = 0) => new ItemInstance<_BaseItem>(item, amount);
         #endregion
     }
 }

--- a/Runtime/Inventory/Slot/Slot.cs
+++ b/Runtime/Inventory/Slot/Slot.cs
@@ -34,10 +34,9 @@ namespace SoulShard.InventorySystem
             string button = ""
         )
         {
-            _ItemInstance originalItem = itemInstance;
-            itemInstance = other;
-            onItemModified?.Invoke(itemInstance);
-            return originalItem;
+            var items = SlotManagementFuncs.Swap<_BaseItem, _ItemInstance>(itemInstance, other);
+            itemInstance = items.Item1;
+            return items.Item2;
         }
     }
 }

--- a/Runtime/Inventory/Slot/SlotManagementFuncs.cs
+++ b/Runtime/Inventory/Slot/SlotManagementFuncs.cs
@@ -62,18 +62,22 @@ namespace SoulShard.InventorySystem
             where _BaseItem : class, IBaseItem
             where _ItemInstance : struct, IItemInstance<_BaseItem>
         {
+            if (current.isEmpty)
+                return Swap<_BaseItem, _ItemInstance>(current, other);
+            if (!other.isEmpty ? current.item != other.item : false)
+                return Swap<_BaseItem, _ItemInstance>(current, other);
             if (!current.item.isStackable)
                 return Swap<_BaseItem, _ItemInstance>(current, other);
             if (current.amount < 2)
                 return Swap<_BaseItem, _ItemInstance>(current, other);
 
-            uint halfStack = (uint)Math.Ceiling((float)current.amount / 2);
+            uint halfStack = (uint)Math.Floor((float)current.amount / 2);
             return (
                 new _ItemInstance() { item = current.item, amount = halfStack },
                 new _ItemInstance()
                 {
                     item = current.item,
-                    amount = other.amount + halfStack + current.amount % 2
+                    amount = other.amount + halfStack + (current.amount % 2)
                 }
             );
         }
@@ -85,16 +89,25 @@ namespace SoulShard.InventorySystem
             where _BaseItem : class, IBaseItem
             where _ItemInstance : struct, IItemInstance<_BaseItem>
         {
+            if (other.isEmpty)
+                return Swap<_BaseItem, _ItemInstance>(current, other);
             if (!other.item.isStackable)
                 return Swap<_BaseItem, _ItemInstance>(current, other);
             if (other.amount < 2)
-                return Swap<_BaseItem, _ItemInstance>(current, other);
+                return (
+                    new _ItemInstance()
+                    {
+                        item = other.item,
+                        amount = current.amount + other.amount
+                    },
+                    new _ItemInstance()
+                );
             if (current.isEmpty)
                 return (
                     new _ItemInstance() { item = other.item, amount = 1 },
                     new _ItemInstance() { item = other.item, amount = other.amount - 1 }
                 );
-            if (current.item != current.item)
+            if (current.item != other.item)
                 return Swap<_BaseItem, _ItemInstance>(current, other);
             if (current.amount == current.item.maxStackAmount)
                 return Swap<_BaseItem, _ItemInstance>(current, other);

--- a/Runtime/Inventory/Slot/SlotManagementFuncs.cs
+++ b/Runtime/Inventory/Slot/SlotManagementFuncs.cs
@@ -1,0 +1,76 @@
+
+using System;
+
+namespace SoulShard.InventorySystem
+{
+    /// <summary>
+    /// All functions within are slot transfer functions that return the slots item, and the other slots item respectively.
+    /// </summary>
+    public struct SlotManagementFuncs
+    {
+        public static (_ItemInstance, _ItemInstance) Swap<_BaseItem, _ItemInstance>(_ItemInstance current, _ItemInstance other)
+            where _BaseItem : class, IBaseItem
+            where _ItemInstance : struct, IItemInstance<IBaseItem>
+        {
+            _ItemInstance originalItem = current;
+            current = other;
+            return (current, originalItem);
+        }
+
+        public static (_ItemInstance, _ItemInstance) CombineStack<_BaseItem, _ItemInstance>(_ItemInstance current, _ItemInstance other)
+            where _BaseItem : class, IBaseItem
+            where _ItemInstance : struct, IItemInstance<IBaseItem>
+        {
+            if (current.isEmpty || other.isEmpty)
+                return Swap<_BaseItem, _ItemInstance>(current, other);
+            if (current.item != other.item)
+                return Swap<_BaseItem, _ItemInstance>(current, other);
+            if (!current.item.isStackable)
+                return Swap<_BaseItem, _ItemInstance>(current, other);
+
+            uint stackSize = other.item.maxStackAmount;
+            if (other.amount >= stackSize)
+                return Swap<_BaseItem, _ItemInstance>(current, other);
+
+            if (other.amount + current.amount < stackSize)
+                return (new _ItemInstance() { item = current.item, amount = current.amount + other.amount }, new _ItemInstance());
+
+            uint leftOver = current.amount + other.amount - stackSize;
+            return (new _ItemInstance() { item = current.item, amount = stackSize }, new _ItemInstance() { item = current.item, amount = leftOver });
+        }
+
+        public static (_ItemInstance, _ItemInstance) HalfStackSplit<_BaseItem, _ItemInstance>(_ItemInstance current, _ItemInstance other)
+            where _BaseItem : class, IBaseItem
+            where _ItemInstance : struct, IItemInstance<IBaseItem>
+        {
+            if (!current.item.isStackable)
+                return Swap<_BaseItem, _ItemInstance>(current, other);
+            if (current.amount < 2)
+                return Swap<_BaseItem, _ItemInstance>(current, other);
+
+            uint halfStack = (uint)Math.Ceiling((float)current.amount / 2);
+            return (
+                new _ItemInstance() { item = current.item, amount = halfStack },
+                new _ItemInstance() { item = current.item, amount = other.amount + halfStack + current.amount % 2 }
+                );
+        }
+
+        public static (_ItemInstance, _ItemInstance) SingleStackSplit<_BaseItem, _ItemInstance>(_ItemInstance current, _ItemInstance other)
+           where _BaseItem : class, IBaseItem
+           where _ItemInstance : struct, IItemInstance<IBaseItem>
+        {
+            if (!other.item.isStackable)
+                return Swap<_BaseItem, _ItemInstance>(current, other);
+            if (other.amount < 2)
+                return Swap<_BaseItem, _ItemInstance>(current, other);
+            if (current.isEmpty)
+                return (new _ItemInstance() { item = other.item, amount = 1 }, new _ItemInstance() { item = other.item, amount=other.amount - 1});
+            if (current.item != current.item)
+                return Swap<_BaseItem, _ItemInstance>(current, other);
+            if (current.amount == current.item.maxStackAmount)
+                return Swap<_BaseItem, _ItemInstance>(current, other);
+
+            return (new _ItemInstance() { item = other.item, amount= current.amount + 1 }, new _ItemInstance() { item = other.item, amount = other.amount - 1 });
+        }
+    }
+}

--- a/Runtime/Inventory/Slot/SlotManagementFuncs.cs
+++ b/Runtime/Inventory/Slot/SlotManagementFuncs.cs
@@ -1,4 +1,3 @@
-
 using System;
 
 namespace SoulShard.InventorySystem
@@ -8,18 +7,24 @@ namespace SoulShard.InventorySystem
     /// </summary>
     public struct SlotManagementFuncs
     {
-        public static (_ItemInstance, _ItemInstance) Swap<_BaseItem, _ItemInstance>(_ItemInstance current, _ItemInstance other)
+        public static (_ItemInstance, _ItemInstance) Swap<_BaseItem, _ItemInstance>(
+            _ItemInstance current,
+            _ItemInstance other
+        )
             where _BaseItem : class, IBaseItem
-            where _ItemInstance : struct, IItemInstance<IBaseItem>
+            where _ItemInstance : struct, IItemInstance<_BaseItem>
         {
             _ItemInstance originalItem = current;
             current = other;
             return (current, originalItem);
         }
 
-        public static (_ItemInstance, _ItemInstance) CombineStack<_BaseItem, _ItemInstance>(_ItemInstance current, _ItemInstance other)
+        public static (_ItemInstance, _ItemInstance) CombineStack<_BaseItem, _ItemInstance>(
+            _ItemInstance current,
+            _ItemInstance other
+        )
             where _BaseItem : class, IBaseItem
-            where _ItemInstance : struct, IItemInstance<IBaseItem>
+            where _ItemInstance : struct, IItemInstance<_BaseItem>
         {
             if (current.isEmpty || other.isEmpty)
                 return Swap<_BaseItem, _ItemInstance>(current, other);
@@ -29,19 +34,33 @@ namespace SoulShard.InventorySystem
                 return Swap<_BaseItem, _ItemInstance>(current, other);
 
             uint stackSize = other.item.maxStackAmount;
-            if (other.amount >= stackSize)
+
+            if (current.amount >= stackSize || other.amount >= stackSize)
                 return Swap<_BaseItem, _ItemInstance>(current, other);
 
             if (other.amount + current.amount < stackSize)
-                return (new _ItemInstance() { item = current.item, amount = current.amount + other.amount }, new _ItemInstance());
+                return (
+                    new _ItemInstance()
+                    {
+                        item = current.item,
+                        amount = current.amount + other.amount
+                    },
+                    new _ItemInstance()
+                );
 
             uint leftOver = current.amount + other.amount - stackSize;
-            return (new _ItemInstance() { item = current.item, amount = stackSize }, new _ItemInstance() { item = current.item, amount = leftOver });
+            return (
+                new _ItemInstance() { item = current.item, amount = stackSize },
+                new _ItemInstance() { item = current.item, amount = leftOver }
+            );
         }
 
-        public static (_ItemInstance, _ItemInstance) HalfStackSplit<_BaseItem, _ItemInstance>(_ItemInstance current, _ItemInstance other)
+        public static (_ItemInstance, _ItemInstance) HalfStackSplit<_BaseItem, _ItemInstance>(
+            _ItemInstance current,
+            _ItemInstance other
+        )
             where _BaseItem : class, IBaseItem
-            where _ItemInstance : struct, IItemInstance<IBaseItem>
+            where _ItemInstance : struct, IItemInstance<_BaseItem>
         {
             if (!current.item.isStackable)
                 return Swap<_BaseItem, _ItemInstance>(current, other);
@@ -51,26 +70,39 @@ namespace SoulShard.InventorySystem
             uint halfStack = (uint)Math.Ceiling((float)current.amount / 2);
             return (
                 new _ItemInstance() { item = current.item, amount = halfStack },
-                new _ItemInstance() { item = current.item, amount = other.amount + halfStack + current.amount % 2 }
-                );
+                new _ItemInstance()
+                {
+                    item = current.item,
+                    amount = other.amount + halfStack + current.amount % 2
+                }
+            );
         }
 
-        public static (_ItemInstance, _ItemInstance) SingleStackSplit<_BaseItem, _ItemInstance>(_ItemInstance current, _ItemInstance other)
-           where _BaseItem : class, IBaseItem
-           where _ItemInstance : struct, IItemInstance<IBaseItem>
+        public static (_ItemInstance, _ItemInstance) SingleStackSplit<_BaseItem, _ItemInstance>(
+            _ItemInstance current,
+            _ItemInstance other
+        )
+            where _BaseItem : class, IBaseItem
+            where _ItemInstance : struct, IItemInstance<_BaseItem>
         {
             if (!other.item.isStackable)
                 return Swap<_BaseItem, _ItemInstance>(current, other);
             if (other.amount < 2)
                 return Swap<_BaseItem, _ItemInstance>(current, other);
             if (current.isEmpty)
-                return (new _ItemInstance() { item = other.item, amount = 1 }, new _ItemInstance() { item = other.item, amount=other.amount - 1});
+                return (
+                    new _ItemInstance() { item = other.item, amount = 1 },
+                    new _ItemInstance() { item = other.item, amount = other.amount - 1 }
+                );
             if (current.item != current.item)
                 return Swap<_BaseItem, _ItemInstance>(current, other);
             if (current.amount == current.item.maxStackAmount)
                 return Swap<_BaseItem, _ItemInstance>(current, other);
 
-            return (new _ItemInstance() { item = other.item, amount= current.amount + 1 }, new _ItemInstance() { item = other.item, amount = other.amount - 1 });
+            return (
+                new _ItemInstance() { item = other.item, amount = current.amount + 1 },
+                new _ItemInstance() { item = other.item, amount = other.amount - 1 }
+            );
         }
     }
 }

--- a/Runtime/Inventory/Slot/SlotManagementFuncs.cs.meta
+++ b/Runtime/Inventory/Slot/SlotManagementFuncs.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 559064973ffb7904694321550286a3a1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Inventory/SoulShard.Inventory.asmdef
+++ b/Runtime/Inventory/SoulShard.Inventory.asmdef
@@ -10,5 +10,5 @@
     "autoReferenced": true,
     "defineConstraints": [],
     "versionDefines": [],
-    "noEngineReferences": false
+    "noEngineReferences": true
 }

--- a/Tests/EditMode/Inventory/Helpers.cs
+++ b/Tests/EditMode/Inventory/Helpers.cs
@@ -1,4 +1,5 @@
 using SoulShard.InventorySystem;
+using NUnit.Framework;
 
 namespace SoulShard.Tests.InventorySystem
 {
@@ -54,5 +55,15 @@ namespace SoulShard.Tests.InventorySystem
                 InventoryManagementUtilities.AddStackableItemToInventory<BaseItem,Slot<BaseItem, ItemInstance<BaseItem>>,ItemInstance<BaseItem>,Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>>,
                 InventoryManagementUtilities.AddUnstackableItemToInventory<BaseItem,Slot<BaseItem, ItemInstance<BaseItem>>,ItemInstance<BaseItem>,Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>>
             };
+
+        public static void AssertEqualToSwap(System.Func<
+            ItemInstance<BaseItem>, ItemInstance<BaseItem>, (ItemInstance<BaseItem>, ItemInstance<BaseItem>)> fn, ItemInstance<BaseItem> current, ItemInstance<BaseItem> other)
+        {
+            var _1 = fn(current, other);
+            Assert.AreEqual(_1.Item1.amount, other.amount);
+            Assert.AreEqual(_1.Item1.item, other.item);
+            Assert.AreEqual(_1.Item2.item, current.item);
+            Assert.AreEqual(_1.Item2.amount, current.amount);
+        }
     }
 }

--- a/Tests/EditMode/Inventory/TestSlot.cs
+++ b/Tests/EditMode/Inventory/TestSlot.cs
@@ -8,7 +8,10 @@ namespace SoulShard.Tests.InventorySystem
         [Test]
         public void TestSlotTransfer()
         {
-            Slot<BaseItem, ItemInstance<BaseItem>> slot = new Slot<BaseItem, ItemInstance<BaseItem>>(new ItemInstance<BaseItem>(Helpers.salt, 12));
+            Slot<BaseItem, ItemInstance<BaseItem>> slot = new Slot<
+                BaseItem,
+                ItemInstance<BaseItem>
+            >(new ItemInstance<BaseItem>(Helpers.salt, 12));
             var res = slot.Transfer(new ItemInstance<BaseItem>(Helpers.AXE));
             Assert.AreEqual(res.amount, 12);
             Assert.AreEqual(res.item.name, Helpers.salt.name);
@@ -20,7 +23,10 @@ namespace SoulShard.Tests.InventorySystem
         public void TestOnItemModifed()
         {
             ItemInstance<BaseItem> res = new ItemInstance<BaseItem>();
-            Slot<BaseItem, ItemInstance<BaseItem>> slot = new Slot<BaseItem, ItemInstance<BaseItem>>(new ItemInstance<BaseItem>(Helpers.salt, 12));
+            Slot<BaseItem, ItemInstance<BaseItem>> slot = new Slot<
+                BaseItem,
+                ItemInstance<BaseItem>
+            >(new ItemInstance<BaseItem>(Helpers.salt, 12));
             slot.onItemModified = (ItemInstance<BaseItem> item) => res = item;
             var testTransfer = new ItemInstance<BaseItem>(Helpers.AXE);
 
@@ -30,6 +36,83 @@ namespace SoulShard.Tests.InventorySystem
             slot.itemInstance = new ItemInstance<BaseItem>();
             Assert.AreEqual(slot.itemInstance.item, res.item);
             Assert.AreEqual(slot.itemInstance.amount, res.amount);
+        }
+
+        [Test]
+        public void TestSwap() =>
+            Helpers.AssertEqualToSwap(
+                SlotManagementFuncs.Swap<BaseItem, ItemInstance<BaseItem>>,
+                new ItemInstance<BaseItem>(Helpers.salt, 1023),
+                new ItemInstance<BaseItem>(Helpers.salt, 12)
+            );
+    }
+
+    class TestCombineStack
+    {
+        [Test]
+        public void TestCombineSimple()
+        {
+            var res = SlotManagementFuncs.CombineStack<BaseItem, ItemInstance<BaseItem>>(
+                new ItemInstance<BaseItem>(Helpers.salt, 10),
+                new ItemInstance<BaseItem>(Helpers.salt, 10)
+            );
+            Assert.AreEqual(res.Item1.amount, 20);
+            Assert.AreEqual(res.Item2.amount, 0);
+            Assert.AreEqual(res.Item1.item, Helpers.salt);
+            Assert.AreEqual(res.Item2.item, null);
+        }
+
+        [Test]
+        public void TestOverflow()
+        {
+            var res = SlotManagementFuncs.CombineStack<BaseItem, ItemInstance<BaseItem>>(
+                new ItemInstance<BaseItem>(Helpers.salt, 70),
+                new ItemInstance<BaseItem>(Helpers.salt, 80)
+            );
+            Assert.AreEqual(res.Item1.amount, 100);
+            Assert.AreEqual(res.Item2.amount, 50);
+            Assert.AreEqual(res.Item1.item, res.Item2.item);
+            Assert.AreEqual(res.Item1.item, Helpers.salt);
+        }
+
+        [Test]
+        public void TestEdgeCases()
+        {
+            Helpers.AssertEqualToSwap(
+                SlotManagementFuncs.CombineStack<BaseItem, ItemInstance<BaseItem>>,
+                new ItemInstance<BaseItem>(),
+                new ItemInstance<BaseItem>(Helpers.salt, 80)
+            );
+            Helpers.AssertEqualToSwap(
+                SlotManagementFuncs.CombineStack<BaseItem, ItemInstance<BaseItem>>,
+                new ItemInstance<BaseItem>(Helpers.salt, 80),
+                new ItemInstance<BaseItem>()
+            );
+            Helpers.AssertEqualToSwap(
+                SlotManagementFuncs.CombineStack<BaseItem, ItemInstance<BaseItem>>,
+                new ItemInstance<BaseItem>(Helpers.salt, 80),
+                new ItemInstance<BaseItem>(Helpers.AXE)
+            );
+            Helpers.AssertEqualToSwap(
+                SlotManagementFuncs.CombineStack<BaseItem, ItemInstance<BaseItem>>,
+                new ItemInstance<BaseItem>(Helpers.witchesBrew, 10),
+                new ItemInstance<BaseItem>(Helpers.salt, 80)
+            );
+            Helpers.AssertEqualToSwap(
+                SlotManagementFuncs.CombineStack<BaseItem, ItemInstance<BaseItem>>,
+                new ItemInstance<BaseItem>(Helpers.AXE, 10),
+                new ItemInstance<BaseItem>(Helpers.AXE, 80)
+            );
+            Helpers.AssertEqualToSwap(
+                SlotManagementFuncs.CombineStack<BaseItem, ItemInstance<BaseItem>>,
+                new ItemInstance<BaseItem>(Helpers.salt, 100),
+                new ItemInstance<BaseItem>(Helpers.salt, 20)
+            );
+            Helpers.AssertEqualToSwap(
+                SlotManagementFuncs.CombineStack<BaseItem, ItemInstance<BaseItem>>,
+                new ItemInstance<BaseItem>(Helpers.salt, 20),
+                new ItemInstance<BaseItem>(Helpers.salt, 100)
+            );
         }
     }
 }

--- a/Tests/EditMode/Inventory/TestSlot.cs
+++ b/Tests/EditMode/Inventory/TestSlot.cs
@@ -115,4 +115,150 @@ namespace SoulShard.Tests.InventorySystem
             );
         }
     }
+
+    class TestHalfSplitStack
+    {
+        [Test]
+        public void TestSimpleSplit()
+        {
+            var res = SlotManagementFuncs.HalfStackSplit<BaseItem, ItemInstance<BaseItem>>(
+                new ItemInstance<BaseItem>(Helpers.salt, 10),
+                new ItemInstance<BaseItem>(Helpers.salt, 2)
+            );
+            Assert.AreEqual(res.Item1.amount, 5);
+            Assert.AreEqual(res.Item2.amount, 7);
+            Assert.AreEqual(res.Item1.item, res.Item2.item);
+            Assert.AreEqual(res.Item1.item, Helpers.salt);
+        }
+
+        [Test]
+        public void TestUnevenSplit()
+        {
+            var res = SlotManagementFuncs.HalfStackSplit<BaseItem, ItemInstance<BaseItem>>(
+                new ItemInstance<BaseItem>(Helpers.salt, 11),
+                new ItemInstance<BaseItem>(Helpers.salt, 3)
+            );
+            Assert.AreEqual(res.Item1.amount, 5);
+            Assert.AreEqual(res.Item2.amount, 9);
+            Assert.AreEqual(res.Item1.item, res.Item2.item);
+            Assert.AreEqual(res.Item1.item, Helpers.salt);
+        }
+
+        [Test]
+        public void TestEdgeCases()
+        {
+            Helpers.AssertEqualToSwap(
+                SlotManagementFuncs.HalfStackSplit<BaseItem, ItemInstance<BaseItem>>,
+                new ItemInstance<BaseItem>(),
+                new ItemInstance<BaseItem>(Helpers.salt, 80)
+            );
+            Helpers.AssertEqualToSwap(
+                SlotManagementFuncs.HalfStackSplit<BaseItem, ItemInstance<BaseItem>>,
+                new ItemInstance<BaseItem>(),
+                new ItemInstance<BaseItem>(Helpers.AXE)
+            );
+            Helpers.AssertEqualToSwap(
+                SlotManagementFuncs.HalfStackSplit<BaseItem, ItemInstance<BaseItem>>,
+                new ItemInstance<BaseItem>(Helpers.AXE),
+                new ItemInstance<BaseItem>()
+            );
+            Helpers.AssertEqualToSwap(
+                SlotManagementFuncs.HalfStackSplit<BaseItem, ItemInstance<BaseItem>>,
+                new ItemInstance<BaseItem>(Helpers.witchesBrew, 20),
+                new ItemInstance<BaseItem>(Helpers.salt, 80)
+            );
+            Helpers.AssertEqualToSwap(
+                SlotManagementFuncs.HalfStackSplit<BaseItem, ItemInstance<BaseItem>>,
+                new ItemInstance<BaseItem>(Helpers.salt, 80),
+                new ItemInstance<BaseItem>(Helpers.witchesBrew, 20)
+            );
+            Helpers.AssertEqualToSwap(
+                SlotManagementFuncs.HalfStackSplit<BaseItem, ItemInstance<BaseItem>>,
+                new ItemInstance<BaseItem>(Helpers.salt, 1),
+                new ItemInstance<BaseItem>()
+            );
+        }
+    }
+
+    class TestSIngleStackSplit
+    {
+        [Test]
+        public void TestSimpleSpLit()
+        {
+            var res = SlotManagementFuncs.SingleStackSplit<BaseItem, ItemInstance<BaseItem>>(
+                new ItemInstance<BaseItem>(Helpers.salt, 20),
+                new ItemInstance<BaseItem>(Helpers.salt, 3)
+            );
+            Assert.AreEqual(res.Item1.amount, 21);
+            Assert.AreEqual(res.Item2.amount, 2);
+            Assert.AreEqual(res.Item1.item, res.Item2.item);
+            Assert.AreEqual(res.Item1.item, Helpers.salt);
+        }
+
+        [Test]
+        public void TestCurrentIsEmpty()
+        {
+            var res = SlotManagementFuncs.SingleStackSplit<BaseItem, ItemInstance<BaseItem>>(
+                new ItemInstance<BaseItem>(),
+                new ItemInstance<BaseItem>(Helpers.salt, 3)
+            );
+            Assert.AreEqual(res.Item1.amount, 1);
+            Assert.AreEqual(res.Item2.amount, 2);
+            Assert.AreEqual(res.Item1.item, res.Item2.item);
+            Assert.AreEqual(res.Item1.item, Helpers.salt);
+        }
+
+        [Test]
+        public void TestRemoveAtEnd()
+        {
+            var res = SlotManagementFuncs.SingleStackSplit<BaseItem, ItemInstance<BaseItem>>(
+                new ItemInstance<BaseItem>(Helpers.salt, 20),
+                new ItemInstance<BaseItem>(Helpers.salt, 1)
+            );
+            Assert.AreEqual(res.Item1.amount, 21);
+            Assert.AreEqual(res.Item2.amount, 0);
+            Assert.AreEqual(res.Item2.item, null);
+            Assert.AreEqual(res.Item1.item, Helpers.salt);
+        }
+
+        [Test]
+        public void TestEdgeCases()
+        {
+            Helpers.AssertEqualToSwap(
+                SlotManagementFuncs.HalfStackSplit<BaseItem, ItemInstance<BaseItem>>,
+                new ItemInstance<BaseItem>(Helpers.salt, 1),
+                new ItemInstance<BaseItem>()
+            );
+            Helpers.AssertEqualToSwap(
+                SlotManagementFuncs.HalfStackSplit<BaseItem, ItemInstance<BaseItem>>,
+                new ItemInstance<BaseItem>(),
+                new ItemInstance<BaseItem>(Helpers.salt, 1)
+            );
+            Helpers.AssertEqualToSwap(
+                SlotManagementFuncs.HalfStackSplit<BaseItem, ItemInstance<BaseItem>>,
+                new ItemInstance<BaseItem>(Helpers.AXE),
+                new ItemInstance<BaseItem>()
+            );
+            Helpers.AssertEqualToSwap(
+                SlotManagementFuncs.HalfStackSplit<BaseItem, ItemInstance<BaseItem>>,
+                new ItemInstance<BaseItem>(),
+                new ItemInstance<BaseItem>(Helpers.AXE)
+            );
+            Helpers.AssertEqualToSwap(
+                SlotManagementFuncs.HalfStackSplit<BaseItem, ItemInstance<BaseItem>>,
+                new ItemInstance<BaseItem>(Helpers.witchesBrew, 5),
+                new ItemInstance<BaseItem>(Helpers.salt, 6)
+            );
+            Helpers.AssertEqualToSwap(
+                SlotManagementFuncs.HalfStackSplit<BaseItem, ItemInstance<BaseItem>>,
+                new ItemInstance<BaseItem>(Helpers.salt, 6),
+                new ItemInstance<BaseItem>(Helpers.witchesBrew, 5)
+            );
+            Helpers.AssertEqualToSwap(
+                SlotManagementFuncs.HalfStackSplit<BaseItem, ItemInstance<BaseItem>>,
+                new ItemInstance<BaseItem>(),
+                new ItemInstance<BaseItem>(Helpers.salt, 100)
+            );
+        }
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.soulshardstudios.soulshardutilities",
-  "version": "0.10.2",
+  "version": "0.10.3",
   "displayName": "SoulShardUtilities",
   "description": "A collection of usefull project independant functions, constants, and utilities.",
   "unity": "2019.1",


### PR DESCRIPTION
Essentially, there are some basic operations other than swapping slots, (stack splitting, stack combining, e.t.c.) that there should be generic functions for. This addresses that issue with some simple essential slot management functions.