### PR TITLE
fix: Return leftover items from inventory add

### DIFF
--- a/Runtime/Inventory/InventorySystem/Inventory.cs
+++ b/Runtime/Inventory/InventorySystem/Inventory.cs
@@ -5,7 +5,8 @@ namespace SoulShard.InventorySystem
     /// </summary>
     /// <typeparam name="_BaseItem">The base item.</typeparam>
     /// <typeparam name="_Slot">The slot type.</typeparam>
-    public class Inventory<_BaseItem, _Slot, _ItemInstance> : IInventory<_BaseItem, _Slot, _ItemInstance>
+    public class Inventory<_BaseItem, _Slot, _ItemInstance>
+        : IInventory<_BaseItem, _Slot, _ItemInstance>
         where _BaseItem : class, IBaseItem
         where _ItemInstance : struct, IItemInstance<_BaseItem>
         where _Slot : class, ISlot<_BaseItem, _ItemInstance>, new()
@@ -14,7 +15,7 @@ namespace SoulShard.InventorySystem
         /// The slots within this inventory.
         /// </summary>
         public _Slot[] slots { get; set; }
-        
+
         /// <summary>
         /// The remaining capacity of this inventory.
         /// </summary>
@@ -40,9 +41,20 @@ namespace SoulShard.InventorySystem
             }
         }
 
-        public virtual void AddItem(_ItemInstance other) => 
-            InventoryManagementUtilities.AddItemToInventory<_BaseItem,_Slot,_ItemInstance,IInventory<_BaseItem,_Slot,_ItemInstance>>(this, other);
-        public virtual void ContainsItem(_ItemInstance other) => 
-            InventoryManagementUtilities.ContainsItem<_BaseItem, _Slot, _ItemInstance, IInventory<_BaseItem, _Slot, _ItemInstance>>(this, other);
+        public virtual _ItemInstance AddItem(_ItemInstance other) =>
+            InventoryManagementUtilities.AddItemToInventory<
+                _BaseItem,
+                _Slot,
+                _ItemInstance,
+                IInventory<_BaseItem, _Slot, _ItemInstance>
+            >(this, other);
+
+        public virtual void ContainsItem(_ItemInstance other) =>
+            InventoryManagementUtilities.ContainsItem<
+                _BaseItem,
+                _Slot,
+                _ItemInstance,
+                IInventory<_BaseItem, _Slot, _ItemInstance>
+            >(this, other);
     }
 }

--- a/Tests/EditMode/Inventory/Helpers.cs
+++ b/Tests/EditMode/Inventory/Helpers.cs
@@ -18,12 +18,20 @@ namespace SoulShard.Tests.InventorySystem
             isStackable: true
         );
 
-        public static Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>> GetFullInventory() =>
+        public static Inventory<
+            BaseItem,
+            Slot<BaseItem, ItemInstance<BaseItem>>,
+            ItemInstance<BaseItem>
+        > GetFullInventory() =>
             new Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>(
                 new ItemInstance<BaseItem>[1] { new ItemInstance<BaseItem>(witchesBrew) }
             );
 
-        public static Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>> GetHoleyInventory() =>
+        public static Inventory<
+            BaseItem,
+            Slot<BaseItem, ItemInstance<BaseItem>>,
+            ItemInstance<BaseItem>
+        > GetHoleyInventory() =>
             new Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>(
                 new ItemInstance<BaseItem>[10]
                 {
@@ -51,13 +59,47 @@ namespace SoulShard.Tests.InventorySystem
                 ItemInstance<BaseItem>
             >[3]
             {
-                InventoryManagementUtilities.AddItemToInventory<BaseItem,Slot<BaseItem, ItemInstance<BaseItem>>,ItemInstance<BaseItem>,Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>>,
-                InventoryManagementUtilities.AddStackableItemToInventory<BaseItem,Slot<BaseItem, ItemInstance<BaseItem>>,ItemInstance<BaseItem>,Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>>,
-                InventoryManagementUtilities.AddUnstackableItemToInventory<BaseItem,Slot<BaseItem, ItemInstance<BaseItem>>,ItemInstance<BaseItem>,Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>>
+                InventoryManagementUtilities.AddItemToInventory<
+                    BaseItem,
+                    Slot<BaseItem, ItemInstance<BaseItem>>,
+                    ItemInstance<BaseItem>,
+                    Inventory<
+                        BaseItem,
+                        Slot<BaseItem, ItemInstance<BaseItem>>,
+                        ItemInstance<BaseItem>
+                    >
+                >,
+                InventoryManagementUtilities.AddStackableItemToInventory<
+                    BaseItem,
+                    Slot<BaseItem, ItemInstance<BaseItem>>,
+                    ItemInstance<BaseItem>,
+                    Inventory<
+                        BaseItem,
+                        Slot<BaseItem, ItemInstance<BaseItem>>,
+                        ItemInstance<BaseItem>
+                    >
+                >,
+                InventoryManagementUtilities.AddUnstackableItemToInventory<
+                    BaseItem,
+                    Slot<BaseItem, ItemInstance<BaseItem>>,
+                    ItemInstance<BaseItem>,
+                    Inventory<
+                        BaseItem,
+                        Slot<BaseItem, ItemInstance<BaseItem>>,
+                        ItemInstance<BaseItem>
+                    >
+                >
             };
 
-        public static void AssertEqualToSwap(System.Func<
-            ItemInstance<BaseItem>, ItemInstance<BaseItem>, (ItemInstance<BaseItem>, ItemInstance<BaseItem>)> fn, ItemInstance<BaseItem> current, ItemInstance<BaseItem> other)
+        public static void AssertEqualToSwap(
+            System.Func<
+                ItemInstance<BaseItem>,
+                ItemInstance<BaseItem>,
+                (ItemInstance<BaseItem>, ItemInstance<BaseItem>)
+            > fn,
+            ItemInstance<BaseItem> current,
+            ItemInstance<BaseItem> other
+        )
         {
             var _1 = fn(current, other);
             Assert.AreEqual(_1.Item1.amount, other.amount);

--- a/Tests/EditMode/Inventory/TestInventoryManagementUtilities.cs
+++ b/Tests/EditMode/Inventory/TestInventoryManagementUtilities.cs
@@ -21,18 +21,24 @@ namespace SoulShard.Tests.InventorySystem
         public void TestAddUnstackableToInventory()
         {
             var inven = Helpers.GetHoleyInventory();
-            InventoryManagementUtilities.AddUnstackableItemToInventory< BaseItem,Slot<BaseItem, ItemInstance<BaseItem>>,ItemInstance<BaseItem>,Inventory<BaseItem,Slot<BaseItem,ItemInstance<BaseItem>>,ItemInstance<BaseItem>>> (
-                inven,
-                new ItemInstance<BaseItem>(Helpers.witchesBrew)
-            );
-            InventoryManagementUtilities.AddUnstackableItemToInventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>, Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>>(
-                inven,
-                new ItemInstance<BaseItem>(Helpers.AXE)
-            );
-            InventoryManagementUtilities.AddUnstackableItemToInventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>, Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>>(
-                inven,
-                new ItemInstance<BaseItem>(Helpers.AXE)
-            );
+            InventoryManagementUtilities.AddUnstackableItemToInventory<
+                BaseItem,
+                Slot<BaseItem, ItemInstance<BaseItem>>,
+                ItemInstance<BaseItem>,
+                Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>
+            >(inven, new ItemInstance<BaseItem>(Helpers.witchesBrew));
+            InventoryManagementUtilities.AddUnstackableItemToInventory<
+                BaseItem,
+                Slot<BaseItem, ItemInstance<BaseItem>>,
+                ItemInstance<BaseItem>,
+                Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>
+            >(inven, new ItemInstance<BaseItem>(Helpers.AXE));
+            InventoryManagementUtilities.AddUnstackableItemToInventory<
+                BaseItem,
+                Slot<BaseItem, ItemInstance<BaseItem>>,
+                ItemInstance<BaseItem>,
+                Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>
+            >(inven, new ItemInstance<BaseItem>(Helpers.AXE));
             Assert.AreEqual(inven.slots[1].itemInstance.item.name, Helpers.witchesBrew.name);
             Assert.AreEqual(inven.slots[2].itemInstance.item.name, Helpers.AXE.name);
             Assert.AreEqual(inven.slots[4].itemInstance.item.name, Helpers.AXE.name);
@@ -42,16 +48,20 @@ namespace SoulShard.Tests.InventorySystem
         public void TestAddStackableItemToInventory()
         {
             var inven = Helpers.GetHoleyInventory();
-            InventoryManagementUtilities.AddStackableItemToInventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>, Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>>(
-                inven,
-                new ItemInstance<BaseItem>(Helpers.salt, 10)
-            );
+            InventoryManagementUtilities.AddStackableItemToInventory<
+                BaseItem,
+                Slot<BaseItem, ItemInstance<BaseItem>>,
+                ItemInstance<BaseItem>,
+                Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>
+            >(inven, new ItemInstance<BaseItem>(Helpers.salt, 10));
             Assert.AreEqual(inven.slots[0].itemInstance.amount, 79);
             Assert.AreEqual(inven.slots[0].itemInstance.item.name, Helpers.salt.name);
-            InventoryManagementUtilities.AddStackableItemToInventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>, Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>>(
-                inven,
-                new ItemInstance<BaseItem>(Helpers.salt, 30)
-            );
+            InventoryManagementUtilities.AddStackableItemToInventory<
+                BaseItem,
+                Slot<BaseItem, ItemInstance<BaseItem>>,
+                ItemInstance<BaseItem>,
+                Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>
+            >(inven, new ItemInstance<BaseItem>(Helpers.salt, 30));
             Assert.AreEqual(inven.slots[0].itemInstance.amount, 100);
             Assert.AreEqual(inven.slots[0].itemInstance.item.name, Helpers.salt.name);
             Assert.AreEqual(inven.slots[1].itemInstance.item.name, Helpers.salt.name);
@@ -63,31 +73,55 @@ namespace SoulShard.Tests.InventorySystem
         {
             var inven = Helpers.GetHoleyInventory();
             Assert.AreEqual(
-                InventoryManagementUtilities.ContainsItem<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>, Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>>(
-                    inven,
-                    new ItemInstance<BaseItem>(Helpers.salt, 69)
-                ),
+                InventoryManagementUtilities.ContainsItem<
+                    BaseItem,
+                    Slot<BaseItem, ItemInstance<BaseItem>>,
+                    ItemInstance<BaseItem>,
+                    Inventory<
+                        BaseItem,
+                        Slot<BaseItem, ItemInstance<BaseItem>>,
+                        ItemInstance<BaseItem>
+                    >
+                >(inven, new ItemInstance<BaseItem>(Helpers.salt, 69)),
                 true
             );
             Assert.AreEqual(
-                InventoryManagementUtilities.ContainsItem<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>, Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>>(
-                    inven,
-                    new ItemInstance<BaseItem>(Helpers.salt, 39)
-                ),
+                InventoryManagementUtilities.ContainsItem<
+                    BaseItem,
+                    Slot<BaseItem, ItemInstance<BaseItem>>,
+                    ItemInstance<BaseItem>,
+                    Inventory<
+                        BaseItem,
+                        Slot<BaseItem, ItemInstance<BaseItem>>,
+                        ItemInstance<BaseItem>
+                    >
+                >(inven, new ItemInstance<BaseItem>(Helpers.salt, 39)),
                 false
             );
             Assert.AreEqual(
-                InventoryManagementUtilities.ContainsItem<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>, Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>>(
-                    inven,
-                    new ItemInstance<BaseItem>(Helpers.AXE, 0)
-                ),
+                InventoryManagementUtilities.ContainsItem<
+                    BaseItem,
+                    Slot<BaseItem, ItemInstance<BaseItem>>,
+                    ItemInstance<BaseItem>,
+                    Inventory<
+                        BaseItem,
+                        Slot<BaseItem, ItemInstance<BaseItem>>,
+                        ItemInstance<BaseItem>
+                    >
+                >(inven, new ItemInstance<BaseItem>(Helpers.AXE, 0)),
                 false
             );
             Assert.AreEqual(
-                InventoryManagementUtilities.ContainsItem<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>, Inventory<BaseItem, Slot<BaseItem, ItemInstance<BaseItem>>, ItemInstance<BaseItem>>>(
-                    inven,
-                    new ItemInstance<BaseItem>(Helpers.witchesBrew, 0)
-                ),
+                InventoryManagementUtilities.ContainsItem<
+                    BaseItem,
+                    Slot<BaseItem, ItemInstance<BaseItem>>,
+                    ItemInstance<BaseItem>,
+                    Inventory<
+                        BaseItem,
+                        Slot<BaseItem, ItemInstance<BaseItem>>,
+                        ItemInstance<BaseItem>
+                    >
+                >(inven, new ItemInstance<BaseItem>(Helpers.witchesBrew, 0)),
                 true
             );
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.soulshardstudios.soulshardutilities",
-  "version": "0.10.8",
+  "version": "0.10.9",
   "displayName": "SoulShardUtilities",
   "description": "A collection of usefull project independant functions, constants, and utilities.",
   "unity": "2019.1",


### PR DESCRIPTION
For some reason in the default inventory class I was not returning the leftover items from the inventory add function, this has been fixed.