### PR TITLE
fix(AnimationController): Expose the normalized time param

### DIFF
--- a/Runtime/Animation/AnimatorController.cs
+++ b/Runtime/Animation/AnimatorController.cs
@@ -15,11 +15,11 @@ namespace SoulShard.Animations
         /// Sets the current animation state to the state specified.
         /// </summary>
         /// <param name="state">The state to change to.</param>
-        protected void ChangeAnimState(string state, int layer = 0)
+        protected void ChangeAnimState(string state, int layer = 0, float normalizedTime = 0)
         {
             if (_currentState == state)
                 return;
-            _animator.Play(state, layer);
+            _animator.Play(state, layer, normalizedTime);
             _currentState = state;
         }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.soulshardstudios.soulshardutilities",
-  "version": "0.10.9",
+  "version": "0.10.10",
   "displayName": "SoulShardUtilities",
   "description": "A collection of usefull project independant functions, constants, and utilities.",
   "unity": "2019.1",


### PR DESCRIPTION
If you need to start the animation at a specific time this aids with
that. No idea why this parameter was hidden in this class.